### PR TITLE
Fix code tool to have correct tooltip

### DIFF
--- a/tools/code.html
+++ b/tools/code.html
@@ -12,7 +12,7 @@
 		<paper-button disabled="[[disabled]]" id="button">
 			<iron-icon icon="code"></iron-icon>
 		</paper-button>
-		<paper-tooltip id="tooltip" for="button" position="[[tooltipPosition]]" offset="5">Undo ([[modifier.tooltip]] + Z)</paper-tooltip>
+		<paper-tooltip id="tooltip" for="button" position="[[tooltipPosition]]" offset="5">Code Block ([[modifier.tooltip]] + Z)</paper-tooltip>
 		<iron-a11y-keys id="a11y" target="[[target]]" keys="shift+alt+c" on-keys-pressed="execCommand"></iron-a11y-keys>
 	</template>
 	<script>


### PR DESCRIPTION
This corrects Code tooltip to show Code Block instead of Undo.