### PR TITLE
fixed incorrect html imports

### DIFF
--- a/app-localize.html
+++ b/app-localize.html
@@ -1,5 +1,5 @@
-<link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../app-localize-behavior/app-localize-behavior.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
 <dom-module id="app-localize">
 	<template>
 		<slot></slot>


### PR DESCRIPTION
HTML imports went one parent directory too far back. This resulted in 404 errors.

This is a tiny fix, but I am using HTML5 PushState in my app, which requires me to serve `index.html` on 404's for url's not beginning with `/bower_components`. Since this element jumps out of `bower_components`, it picked a fight with this system.