### PR TITLE
Possible fix for #168

### DIFF
--- a/wysiwyg-e.html
+++ b/wysiwyg-e.html
@@ -498,7 +498,7 @@ Command                                 | Mac Shortcut                          
 				super.disconnectedCallback();
 				window.removeEventListener('resize', this._resizeHandler);
 				this.removeEventListener('keydown', this._keydownHandler);
-				this.removeEventListener('restore-selection', this._restoreSelectionHandler);
+				this.$.toolbar.removeEventListener('restore-selection', this._restoreSelectionHandler);
 				this.removeEventListener('select-element', this._selectElementHandler);
 				this.$.editable.removeEventListener('paste', this._pasteHandler);
 				this.$.tools.removeEventListener('slotchange', this._slotchangeHandler);

--- a/wysiwyg-e.html
+++ b/wysiwyg-e.html
@@ -483,7 +483,7 @@ Command                                 | Mac Shortcut                          
 					}.bind(this);
 				}
 
-				this.addEventListener('paste', this._pasteHandler);
+				this.$.editable.addEventListener('paste', this._pasteHandler);
 
 				if (!this._slotchangeHandler) {
 					this._slotchangeHandler = function () {
@@ -500,7 +500,7 @@ Command                                 | Mac Shortcut                          
 				this.removeEventListener('keydown', this._keydownHandler);
 				this.removeEventListener('restore-selection', this._restoreSelectionHandler);
 				this.removeEventListener('select-element', this._selectElementHandler);
-				this.removeEventListener('paste', this._pasteHandler);
+				this.$.editable.removeEventListener('paste', this._pasteHandler);
 				this.$.tools.removeEventListener('slotchange', this._slotchangeHandler);
 			}
 

--- a/wysiwyg-e.html
+++ b/wysiwyg-e.html
@@ -480,6 +480,7 @@ Command                                 | Mac Shortcut                          
 						// If paste does not contain HTML, fall back to plain text
 						if (!data.length) data = event.clipboardData.getData('text');
 						document.execCommand('insertHTML', false, data);
+						this.value = this.$.editable.innerHTML;
 					}.bind(this);
 				}
 


### PR DESCRIPTION
This fixes the pasting issue in #168.

This fixes the issue by finishing the paste event handler with updating `value` with the current value of `innerHTML` of `#editable`.

Since this is the first piece of code that sets `this.value` like this, so this might not be the preferred way to go about it.